### PR TITLE
improve permissions for update_schema workflow

### DIFF
--- a/.github/workflows/update_schema.yml
+++ b/.github/workflows/update_schema.yml
@@ -3,6 +3,10 @@ name: Update database schema
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_schema:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_schema.yml
+++ b/.github/workflows/update_schema.yml
@@ -65,3 +65,5 @@ jobs:
             - Backup date: ${{ steps.date.outputs.yesterday }}
           branch: update-schema
           delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true


### PR DESCRIPTION
PR creation was failing with
```
  remote: Permission to chgk-gg/rating-db.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/chgk-gg/rating-db/': The requested URL returned error: 403
```