### PR TITLE
use postgres 17 in sqlite backup creation

### DIFF
--- a/.github/workflows/create_sqlite_backup.yml
+++ b/.github/workflows/create_sqlite_backup.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -31,12 +31,12 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install "db-to-sqlite[postgresql]"
 
-      - name: Install PostgreSQL 15 client
+      - name: Install PostgreSQL 17 client
         run: |
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install -y postgresql-client-15
+          sudo apt-get install -y postgresql-client-17
 
       - name: Calculate yesterday’s date
         id: date


### PR DESCRIPTION


pg_dump in the rating-ui container is now 17.6, so backups created by it cannot be restored by pg_restore 15.x (even though these backups come from a 15.x database).

